### PR TITLE
Support Elixir 1.18 in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
        matrix:
-         elixir: ["1.14", "1.15", "1.16", "1.17"]
-         otp: [24, 25, 26, 27]
+         elixir: ["1.14", "1.15", "1.16", "1.17", "1.18"]
+         otp: ["24", "25", "26", "27"]
          exclude:
-          - elixir: "1.14"
-            otp: "27"
-          - elixir: "1.15"
-            otp: "27"
-          - elixir: "1.16"
-            otp: "27"
-          - elixir: "1.17"
-            otp: "24"
+           - elixir: "1.14"
+             otp: "27"
+           - elixir: "1.15"
+             otp: "27"
+           - elixir: "1.16"
+             otp: "27"
+           - elixir: "1.17"
+             otp: "24"
+           - elixir: "1.18"
+             otp: "24"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.2
-erlang 27.0.1
+elixir 1.18.2
+erlang 27.2.2


### PR DESCRIPTION
Other changes:
- bump versions for asdf
- fix incorrect indentation in `ci.yml`
- specify versions as strings, not numbers